### PR TITLE
Changes expectation to match description in Ruby docs.

### DIFF
--- a/spec/refresher_spec.rb
+++ b/spec/refresher_spec.rb
@@ -47,7 +47,7 @@ describe 'Refresher' do
     end
 
     it "removes an item from the front of an array" do
-      expect([1, "banana"]._fill_in_method_here_).to eq ["banana"]
+      expect([1, "banana"]._fill_in_method_here_).to eq 1
     end
   end
 


### PR DESCRIPTION
The test example return value didn't match the Ruby docs for the method that "removes an item from the front of an array". I've changed this to the appropriate return value.

from http://ruby-doc.org/core-2.2.0/Array.html#method-i-shift

```
shift → obj or nil click to toggle source
shift(n) → new_ary
Removes the first element of self and returns it (shifting all other elements down by one). Returns nil if the array is empty.

If a number n is given, returns an array of the first n elements (or less) just like array.slice!(0, n) does. With ary containing only the remainder elements, not including what was shifted to new_ary. See also unshift for the opposite effect.
```
